### PR TITLE
Fix: Add neighbours for connected nodes

### DIFF
--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -39,6 +39,11 @@
 {%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
 {%                     do avd_ext_node_dict[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     do nodes_list.append(avd_ext_node_dict) %}
+{%                     set neighbordict = dict() %}
+{%                     do neighbordict.update({"neighborDevice": ifdata["peer"]}) %}
+{%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
+{%                     do neighbordict.update({"port": interface}) %}
+{%                     do node_dict[node]["neighbors"].append(neighbordict) %}
 {%                 elif act_add_connected_nodes == false %}
 {%                     do node_dict[node].ports.append(interface) %}
 {%                 endif %}
@@ -48,7 +53,7 @@
 {%     endif %}
 {% endfor %}
 {% if act_add_cvp %}
-{%     do nodes_list.append({"cvp": {"ip_addr": "192.168.0.5", "node_type": "cvp"}}) %}
+{%     do nodes_list.append({ "cvp": {"ip_addr": "192.168.0.5", "node_type": "cvp"}}) %}
 {% endif %}
 {% if act_add_ansible_node %}
 {%     do nodes_list.append({"ansible": {"ip_addr": "192.168.0.6", "node_type": "generic"}}) %}


### PR DESCRIPTION
# Fixes:
- Adds neighbours to Leafs/Devices with L3 Peers when `act_add_connected_nodes` is set