### PR TITLE
Fix: missing ports if no peer definitions

### DIFF
--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -44,9 +44,9 @@
 {%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
 {%                     do neighbordict.update({"port": interface}) %}
 {%                     do node_dict[node]["neighbors"].append(neighbordict) %}
-{%                 elif act_add_connected_nodes == false %}
-{%                     do node_dict[node].ports.append(interface) %}
 {%                 endif %}
+{%             elif act_add_connected_nodes == false %}
+{%                 do node_dict[node].ports.append(interface) %}
 {%             endif %}
 {%         endfor %}
 {%         do nodes_list.append(node_dict) %}


### PR DESCRIPTION
## Fix
This should fix missing ports for ethernet_interfaces that do not have a peer and peer_interface definition. 
