### PR TITLE
Fix: missing connected host interfaces

### DIFF
--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -23,7 +23,18 @@ act_cvp_instance_type: "singlenode" # Currently the only supported type
 # Whether to add cvp and ansible node to topology
 act_add_cvp: true
 act_add_ansible_node: true
+
+# Whether to add nodes that are not defined in the fabric
+# Example l3 peers, servers and other endpoints
 act_add_connected_nodes: false
+# For each peer_type that should be added,
+# the ACT node_type needs to be defined
+# Any peer_type that is not defined in this list
+# will not be added as a node in the topology
+act_connected_nodes_map: 
+  other: 'veos'
+  # network_port: 'generic'
+  # server: 'generic'
 
 # # Extra nodes to add
 # act_additional_nodes: []

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -33,11 +33,13 @@ act_add_connected_nodes: false
 # the ACT node_type needs to be defined
 # Any peer_type that is not defined in this list
 # will not be added as a node in the topology
-act_connected_nodes_map:
+act_connected_nodes_map: 
   other: 'veos'
-  server: 'generic'
+  # server: 'generic'
   # network_port: 'generic'
   # <peer_type in AVD>: <node_type in ACT>
+
+act_connected_nodes_range: 192.168.0.128/25
 
 # # Extra nodes to add
 # act_additional_nodes: []

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -18,7 +18,7 @@ act_device_password: "arista1234"
 # CVP user/pass
 act_cvp_user: "root"
 act_cvp_password: "cvproot"
-act_cvp_instance_type: "singlenode" # Currently the only supported type
+act_cvp_instance_type: "singlenode"  # Currently the only supported type
 
 # Whether to add cvp and ansible node to topology
 act_add_cvp: true
@@ -31,10 +31,11 @@ act_add_connected_nodes: false
 # the ACT node_type needs to be defined
 # Any peer_type that is not defined in this list
 # will not be added as a node in the topology
-act_connected_nodes_map: 
+act_connected_nodes_map:
   other: 'veos'
+  server: 'generic'
   # network_port: 'generic'
-  # server: 'generic'
+  # <peer_type in AVD>: <node_type in ACT>
 
 # # Extra nodes to add
 # act_additional_nodes: []

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -1,5 +1,6 @@
 {# Build nodes_data.nodes_list #}
 {% set nodes_list = [] %}
+{% set other_nodes = {} %}
 {% for node in ansible_play_hosts_all | arista.avd.natural_sort %}
 {%     if hostvars[node].ethernet_interfaces is defined %}
 {%         set node_dict = dict() %}
@@ -24,21 +25,23 @@
 {%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
 {%                     do neighbordict.update({"port": interface}) %}
 {%                     do node_dict[node]["neighbors"].append(neighbordict) %}
-{#                 add non-fabric connected nodes if toggle is set #}
-{%                 elif act_add_connected_nodes == true %}
+{#                 add non-fabric connected nodes if toggle is set and peer_type is within given map #}
+{%                 elif act_add_connected_nodes == true and ifdata["peer_type"] in act_connected_nodes_map %}
 {%                     set peer_node = ifdata["peer"] %}
-{%                     set avd_ext_node_dict = dict() %}
-{%                     do avd_ext_node_dict.update({peer_node: dict()}) %}
-{%                     do avd_ext_node_dict[peer_node].update({"ip_addr": "192.168.1.1" ~ loop.index}) %}
-{%                     do avd_ext_node_dict[peer_node].update({"node_type": "generic"}) %}
-{%                     do avd_ext_node_dict[peer_node].update({"neighbors": []}) %}
-{%                     do avd_ext_node_dict[peer_node].update({"ports": []}) %}
 {%                     set avd_ext_node_neighbordict = dict() %}
 {%                     do avd_ext_node_neighbordict.update({"neighborDevice": node}) %}
 {%                     do avd_ext_node_neighbordict.update({"neighborPort": interface}) %}
 {%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
-{%                     do avd_ext_node_dict[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
-{%                     do nodes_list.append(avd_ext_node_dict) %}
+{%                     if peer_node not in other_nodes %}
+{%                         do other_nodes.update({peer_node: dict()}) %}
+{%                         do other_nodes[peer_node].update({"ip_addr": "192.168.1.1" ~ loop.index}) %}
+{%                         do other_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
+{%                         do other_nodes[peer_node].update({"neighbors": []}) %}
+{%                         do other_nodes[peer_node].update({"ports": []}) %}
+{%                         do other_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
+{%                     else %}
+{%                         do other_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict)%}
+{%                     endif %}
 {%                     set neighbordict = dict() %}
 {%                     do neighbordict.update({"neighborDevice": ifdata["peer"]}) %}
 {%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
@@ -53,6 +56,10 @@
 {%         endfor %}
 {%         do nodes_list.append(node_dict) %}
 {%     endif %}
+{% endfor %}
+{# Add the other nodes to the list #}
+{% for node in other_nodes %}
+{%   do nodes_list.append({node: other_nodes[node]})%}
 {% endfor %}
 {% if act_add_cvp %}
 {%     do nodes_list.append({ "cvp": {"ip_addr": "192.168.0.5", "node_type": "cvp"}}) %}

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -1,6 +1,7 @@
 {# Build nodes_data.nodes_list #}
 {% set nodes_list = [] %}
 {% set avd_ext_nodes = {} %}
+{% set ns = namespace(avd_ext_nodes_count = 0) %}
 {% for node in ansible_play_hosts_all | arista.avd.natural_sort %}
 {%     if hostvars[node].ethernet_interfaces is defined %}
 {%         set node_dict = dict() %}
@@ -34,7 +35,9 @@
 {%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
 {%                     if peer_node not in avd_ext_nodes %}
 {%                         do avd_ext_nodes.update({peer_node: dict()}) %}
-{%                         do avd_ext_nodes[peer_node].update({"ip_addr": "192.168.1.1" ~ loop.index}) %}
+{%                         set mgmt_ip = act_connected_nodes_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(ns.avd_ext_nodes_count)  %}
+{%                         set ns.avd_ext_nodes_count = ns.avd_ext_nodes_count + 1 %}
+{%                         do avd_ext_nodes[peer_node].update({"ip_addr": mgmt_ip}) %}
 {%                         do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
 {%                         do avd_ext_nodes[peer_node].update({"neighbors": []}) %}
 {%                         do avd_ext_nodes[peer_node].update({"ports": []}) %}

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -44,6 +44,8 @@
 {%                     do neighbordict.update({"neighborPort": ifdata["peer_interface"]}) %}
 {%                     do neighbordict.update({"port": interface}) %}
 {%                     do node_dict[node]["neighbors"].append(neighbordict) %}
+{%                 else %}
+{%                     do node_dict[node].ports.append(interface) %}
 {%                 endif %}
 {%             elif act_add_connected_nodes == false %}
 {%                 do node_dict[node].ports.append(interface) %}

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -50,7 +50,7 @@
 {%                 else %}
 {%                     do node_dict[node].ports.append(interface) %}
 {%                 endif %}
-{%             elif act_add_connected_nodes == false and "." not in interface %}
+{%             elif "." not in interface %}
 {%                 do node_dict[node].ports.append(interface) %}
 {%             endif %}
 {%         endfor %}

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -1,6 +1,6 @@
 {# Build nodes_data.nodes_list #}
 {% set nodes_list = [] %}
-{% set other_nodes = {} %}
+{% set avd_ext_nodes = {} %}
 {% for node in ansible_play_hosts_all | arista.avd.natural_sort %}
 {%     if hostvars[node].ethernet_interfaces is defined %}
 {%         set node_dict = dict() %}
@@ -32,15 +32,15 @@
 {%                     do avd_ext_node_neighbordict.update({"neighborDevice": node}) %}
 {%                     do avd_ext_node_neighbordict.update({"neighborPort": interface}) %}
 {%                     do avd_ext_node_neighbordict.update({"port": ifdata["peer_interface"]}) %}
-{%                     if peer_node not in other_nodes %}
-{%                         do other_nodes.update({peer_node: dict()}) %}
-{%                         do other_nodes[peer_node].update({"ip_addr": "192.168.1.1" ~ loop.index}) %}
-{%                         do other_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
-{%                         do other_nodes[peer_node].update({"neighbors": []}) %}
-{%                         do other_nodes[peer_node].update({"ports": []}) %}
-{%                         do other_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
+{%                     if peer_node not in avd_ext_nodes %}
+{%                         do avd_ext_nodes.update({peer_node: dict()}) %}
+{%                         do avd_ext_nodes[peer_node].update({"ip_addr": "192.168.1.1" ~ loop.index}) %}
+{%                         do avd_ext_nodes[peer_node].update({"node_type": act_connected_nodes_map[ifdata["peer_type"]]}) %}
+{%                         do avd_ext_nodes[peer_node].update({"neighbors": []}) %}
+{%                         do avd_ext_nodes[peer_node].update({"ports": []}) %}
+{%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     else %}
-{%                         do other_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict)%}
+{%                         do avd_ext_nodes[peer_node]["neighbors"].append(avd_ext_node_neighbordict) %}
 {%                     endif %}
 {%                     set neighbordict = dict() %}
 {%                     do neighbordict.update({"neighborDevice": ifdata["peer"]}) %}
@@ -58,8 +58,8 @@
 {%     endif %}
 {% endfor %}
 {# Add the other nodes to the list #}
-{% for node in other_nodes %}
-{%   do nodes_list.append({node: other_nodes[node]})%}
+{% for node in avd_ext_nodes %}
+{%    do nodes_list.append({node: avd_ext_nodes[node]})%}
 {% endfor %}
 {% if act_add_cvp %}
 {%     do nodes_list.append({ "cvp": {"ip_addr": "192.168.0.5", "node_type": "cvp"}}) %}


### PR DESCRIPTION
## Fixes
- When connected hosts have multiple links, multiple nodes are created instead of 1 node with multiple neighbors
- Missing interfaces if : 
  - `act_add_connected_nodes` is false
  - `peer` and `peer_interface` are defined for the `ethernet_interface` in question.

## Adds
- Define a map of AVD peer_type to ACT node_type, to define what kind of node we want in ACT
- Use above map to define which peer_types we want to create nodes for (example: only for 'server' or 'other')
- Define the IP range for mgmt interface of external nodes 