### PR TITLE
FIX: remove cvp username and password for autoconf

### DIFF
--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -130,7 +130,7 @@
 {%     do nodes_list.append({ node: avd_ext_nodes[node] }) %}
 {% endfor %}
 {% if act_add_cvp and act_cvp_auto_configuration %}
-{%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp", "auto_configuration": act_cvp_auto_configuration, "username":act_device_user, "password":act_device_password }}) %}
+{%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp", "auto_configuration": act_cvp_auto_configuration }}) %}
 {% elif act_add_cvp %}
 {%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp" }}) %}
 {% endif %}


### PR DESCRIPTION
Newer versions of ACT no longer require a `username` and `password` defined under the `cvp` node in order for auto-configuration to work. 

This change removes the `username` and `password` fields from `cvp` node from the generated topology.