### PR TITLE
FEAT: Support custom topology filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Use the same top level group you have for your fabric for hosts, modify the inpu
 structured_folder: "intended/structured_configs/"
 avd_structured_config_file_format: yml
 output_folder: "act/"
+output_filename: "topology.yml"
 
 # Versions
 act_eos_version: "4.28.1.1F"

--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -30,6 +30,7 @@ Use the same top level group you have for your fabric for hosts, modify the inpu
 structured_folder: "intended/structured_configs/"
 avd_structured_config_file_format: yml
 output_folder: "act/"
+output_filename: "topology.yml"
 
 # Versions
 act_eos_version: "4.28.1.1F"

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -5,6 +5,7 @@
 structured_folder: "intended/structured_configs/"
 avd_structured_config_file_format: yml
 output_folder: "act/"
+output_filename: "topology.yml"
 
 # Versions
 act_eos_version: "4.28.1.1F"

--- a/act-topgen/tasks/main.yml
+++ b/act-topgen/tasks/main.yml
@@ -23,5 +23,5 @@
   run_once: true
   template:
     src: main.j2
-    dest: "{{ output_folder }}/topology.yml"
+    dest: "{{ output_folder }}/{{ output_filename }}"
     mode: 0664

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -130,7 +130,7 @@
 {%     do nodes_list.append({ node: avd_ext_nodes[node] }) %}
 {% endfor %}
 {% if act_add_cvp and act_cvp_auto_configuration %}
-{%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp", "auto_configuration": act_cvp_auto_configuration, "username":act_device_user, "password":act_device_password }}) %}
+{%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp", "auto_configuration": act_cvp_auto_configuration }}) %}
 {% elif act_add_cvp %}
 {%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp" }}) %}
 {% endif %}


### PR DESCRIPTION
At the moment, the filename of the topology uploaded to ACT needs to be unique, but the act_topgen role still creates all topologies with the name `topology.yml`.

This change allows the name to be specified using the `output_filename` variable, that is still set to `topology.yml` by default to support previous behaviour.
This makes it easy to keep generating the topology with the right filename straight away rather than having to make sure to rename the file each time.