### PR TITLE
FEAT: Add support for extra vEOS ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ act_cvp_version: "2022.2.2"
 # Device (veos/generic) user/pass
 act_device_user: "cvpadmin"
 act_device_password: "arista1234"
+# List other ports that all EOS devices should have.
+# These cannot clash with ports already defined through the topology.
+act_default_ports: []
 
 # CVP user/pass
 act_cvp_user: "root"

--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -40,6 +40,9 @@ act_cvp_version: "2022.2.2"
 # Device (veos/generic) user/pass
 act_device_user: "cvpadmin"
 act_device_password: "arista1234"
+# List other ports that all EOS devices should have.
+# These cannot clash with ports already defined through the topology.
+act_default_ports: []
 
 # CVP user/pass
 act_cvp_user: "root"

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -15,6 +15,9 @@ act_cvp_version: "2022.2.2"
 # Device (veos/generic) user/pass
 act_device_user: "cvpadmin"
 act_device_password: "arista1234"
+# List other ports that all EOS devices should have.
+# These cannot clash with ports already defined through the topology.
+act_default_ports: []
 
 # CVP user/pass
 act_cvp_user: "root"

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -7,7 +7,7 @@
 {% for node in ansible_play_hosts_all | arista.avd.natural_sort %}
 {%     if hostvars[node].ethernet_interfaces is defined %}
 {%         set node_dict = dict() %}
-{%         set nodename = node | replace("_", "-")%}
+{%         set nodename = node | replace("_", "-") %}
 {%         do node_dict.update({nodename: dict()}) %}
 {# {%         do node_dict[nodename].update({"ip_addr": "192.168.0.1" ~ loop.index}) %} #}
 {%         set node_mgmt_interfaces = [] %}
@@ -123,6 +123,8 @@
 {%             endif %}
 {%         endfor %}
 {%         do nodes_list.append(node_dict) %}
+{#      Add default ports to the node #}
+{%         do node_dict[node].ports.extend(act_default_ports) %}
 {%     endif %}
 {% endfor %}
 {# Add the other nodes to the list #}


### PR DESCRIPTION
Add support to define extra vEOS ports that
should be added to each vEOS device.

At the moment once the topology is generated, we need to manually go and add extra ports to vEOS devices that we want to have extra ports than the ones already defined.

Example:
```yaml

nodes:
  # If the below node is automatically generated, only EthernetX that is defined in the fabric is added
  - node1:
      ip_addr: 172.16.1.111
      node_type: veos
      ports:
      - Ethernet 5
```

Proposed solution

```yaml
# by setting the below variable in the playbook/inventory
        act_default_ports: [ Ethernet10-20 ]
# the role will automatically add Ethernet10-20 to each device
```
```yaml

nodes:
  # If the below node is automatically generated, only EthernetX that is defined in the fabric is added
  - node1:
      ip_addr: 172.16.1.111
      node_type: veos
      ports:
      - Ethernet 5
      - Ethernet10-20
```