### PR TITLE
Feat: Fallback IP Range for nodes ip_addr assignment

### DIFF
--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -46,6 +46,8 @@ act_connected_nodes_map:
   # <peer_type in AVD>: <node_type in ACT>
 
 act_connected_nodes_range: 192.168.0.128/25
+# Only used if there are no management interfaces in the AVD structured config from which to source ip_addr assignment.
+eos_devices_mgmt_ip_range: 192.168.0.0/25
 
 # # Extra nodes to add
 # act_additional_nodes: []

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -19,11 +19,16 @@
 {%         elif hostvars[node].management_interfaces is defined %}
 {%             set node_mgmt_interfaces = hostvars[node].management_interfaces %}
 {%         endif %}
-{%         for mgmt_if in node_mgmt_interfaces %}
-{%             set node_mgmt_ip = mgmt_if.ip_address | split("/") %}
-{%             do node_dict[nodename].update({"ip_addr": node_mgmt_ip[0]}) %}
-{%             break %}
-{%         endfor %}
+{%         if node_mgmt_interfaces | length > 0 %}
+{%             for mgmt_if in node_mgmt_interfaces %}
+{%                 set node_mgmt_ip = mgmt_if.ip_address | split("/") %}
+{%                 do node_dict[nodename].update({"ip_addr": node_mgmt_ip[0]}) %}
+{%                 break %}
+{%             endfor %}
+{%         else %}
+{%             set node_mgmt_ip = eos_devices_mgmt_ip_range | ansible.utils.ipaddr('network') | ansible.utils.ipmath(10 + loop.index0) %}
+{%             do node_dict[nodename].update({"ip_addr": node_mgmt_ip}) %}
+{%         endif %}
 {%         do node_dict[nodename].update({"node_type": "veos"}) %}
 {%         if act_use_old_connections %}
 {%             do node_dict[nodename].update({"neighbors": []}) %}


### PR DESCRIPTION
If no mgmt_ip is assigned by AVD this role does not generate any ip_addr for ACT to assign to the nodes. This forces people  to manually update their topologies. 

This PR adds an IP range variable to use as fallback.