### PR TITLE
Feat: Add device model capability based on metadata and associated toggle

### DIFF
--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -43,6 +43,8 @@ act_device_password: "arista1234"
 # List other ports that all EOS devices should have.
 # These cannot clash with ports already defined through the topology.
 act_default_ports: []
+# Adds device models from structured config metadata if present
+act_use_device_models: true
 
 # CVP user/pass
 act_cvp_user: "root"

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -18,6 +18,8 @@ act_device_password: "arista1234"
 # List other ports that all EOS devices should have.
 # These cannot clash with ports already defined through the topology.
 act_default_ports: []
+# Adds device models from structured config metadata if present
+act_use_device_models: true
 
 # CVP user/pass
 act_cvp_user: "root"

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -39,6 +39,13 @@
 {%         else %}
 {%             set node_ethernet_interfaces = hostvars[node].ethernet_interfaces %}
 {%         endif %}
+{%         if hostvars[node].metadata is defined %}
+{%             if hostvars[node].metadata.platform is defined and hostvars[node].metadata.platform is not none %}
+{%                 if hostvars[node].metadata.platform | lower is not in ["veos-lab", "veos_lab", "veos", "ceos-lab", "ceos_lab", "ceos"] %}
+{%                     do node_dict[nodename].update({"device_model": hostvars[node].metadata.platform }) %}
+{%                 endif %}
+{%             endif %}
+{%         endif %}
 {#         building links definition as per new ACT standard #}
 {%         if not act_use_old_connections %}
 {%             for ifdata in node_ethernet_interfaces %}

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -39,10 +39,12 @@
 {%         else %}
 {%             set node_ethernet_interfaces = hostvars[node].ethernet_interfaces %}
 {%         endif %}
-{%         if hostvars[node].metadata is defined %}
-{%             if hostvars[node].metadata.platform is defined and hostvars[node].metadata.platform is not none %}
-{%                 if hostvars[node].metadata.platform | lower is not in ["veos-lab", "veos_lab", "veos", "ceos-lab", "ceos_lab", "ceos"] %}
-{%                     do node_dict[nodename].update({"device_model": hostvars[node].metadata.platform }) %}
+{%         if act_use_device_models is true %}
+{%             if hostvars[node].metadata is defined %}
+{%                 if hostvars[node].metadata.platform is defined and hostvars[node].metadata.platform is not none %}
+{%                     if hostvars[node].metadata.platform | lower is not in ["veos-lab", "veos_lab", "veos", "ceos-lab", "ceos_lab", "ceos"] %}
+{%                         do node_dict[nodename].update({"device_model": hostvars[node].metadata.platform }) %}
+{%                     endif %}
 {%                 endif %}
 {%             endif %}
 {%         endif %}


### PR DESCRIPTION
Adds new knob "act_use_device_models" which defaults to true and uses structured config metadata to add device models to generated act topologies.

To not use device models (keeping the old behavior), set new key to false.

Note: veos/ceos device models are not translated to the generated topology files as only hardware model names are supported in ACT.