### PR TITLE
Feat: Add additional nodes/links capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ act_connected_nodes_map:
 
 act_connected_nodes_range: 192.168.0.128/25
 
-# # Extra nodes to add
+# Extra nodes and links to add
 act_additional_nodes: []
+act_additional_links: []
 
 # Use older style ACT topology connections (nodes[].neighbors)
 act_use_old_connections: false

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ act_connected_nodes_map:
 act_connected_nodes_range: 192.168.0.128/25
 
 # # Extra nodes to add
-# act_additional_nodes: []
+act_additional_nodes: []
 
 # Use older style ACT topology connections (nodes[].neighbors)
 act_use_old_connections: false

--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -80,8 +80,9 @@ act_connected_nodes_map:
 
 act_connected_nodes_range: 192.168.0.128/25
 
-# # Extra nodes to add
+# Extra nodes and links to add
 act_additional_nodes: []
+act_additional_links: []
 
 # Use older style ACT topology connections (nodes[].neighbors)
 act_use_old_connections: false

--- a/act-topgen/README.md
+++ b/act-topgen/README.md
@@ -81,7 +81,7 @@ act_connected_nodes_map:
 act_connected_nodes_range: 192.168.0.128/25
 
 # # Extra nodes to add
-# act_additional_nodes: []
+act_additional_nodes: []
 
 # Use older style ACT topology connections (nodes[].neighbors)
 act_use_old_connections: false

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -52,7 +52,7 @@ act_connected_nodes_map:
 
 act_connected_nodes_range: 192.168.0.128/25
 
-# # Extra nodes and links to add
+# Extra nodes and links to add
 act_additional_nodes: []
 act_additional_links: []
 

--- a/act-topgen/defaults/main.yml
+++ b/act-topgen/defaults/main.yml
@@ -52,8 +52,9 @@ act_connected_nodes_map:
 
 act_connected_nodes_range: 192.168.0.128/25
 
-# # Extra nodes to add
-# act_additional_nodes: []
+# # Extra nodes and links to add
+act_additional_nodes: []
+act_additional_links: []
 
 # Use older style ACT topology connections (nodes[].neighbors)
 act_use_old_connections: false

--- a/act-topgen/templates/logic.j2
+++ b/act-topgen/templates/logic.j2
@@ -145,6 +145,12 @@
 {% for node in avd_ext_nodes %}
 {%     do nodes_list.append({ node: avd_ext_nodes[node] }) %}
 {% endfor %}
+{% for node in act_additional_nodes %}
+{%     do nodes_list.append(node) %}
+{% endfor %}
+{% for link in act_additional_links %}
+{%     do act_links.append(link) %}
+{% endfor %}
 {% if act_add_cvp and act_cvp_auto_configuration %}
 {%     do nodes_list.append({ "cvp": {"ip_addr": act_cvp_ip, "node_type": "cvp", "auto_configuration": act_cvp_auto_configuration, "instance_type": act_cvp_size }}) %}
 {% elif act_add_cvp %}


### PR DESCRIPTION
Adds knobs for supplying additional nodes to build the topology as well as additional links.

```yaml
# Extra nodes and links to add
act_additional_nodes: []
act_additional_links: []
```

Structure of links and nodes to add must conform to ACT standard which may change over time, no validation is done on the formatting.

Additional links knob only compatible with new way of building links. If using old standard, you have to specify links under the node.